### PR TITLE
Refactor legacy contract

### DIFF
--- a/gbmplus/__init__.py
+++ b/gbmplus/__init__.py
@@ -99,7 +99,10 @@ class GBMPlusAPI(object):
         # API endpoints by section
         self.accounts = Accounts(self._session) 
         self.transfers = Transfers(self._session)
-        self.orders = Orders(self._session, trading_types=TradingTypes)
+        self.orders = Orders(self._session,
+                             accounts={element["name"]: element for element in self.accounts.getAccounts()},
+                             trading_types=TradingTypes
+        )
         self.tradingUSA = TradingUSA(self._session)
 
 

--- a/gbmplus/__init__.py
+++ b/gbmplus/__init__.py
@@ -8,6 +8,7 @@ from .api.accounts import Accounts
 from .api.transfers import Transfers
 from .api.orders import Orders
 from .api.tradingUSA import TradingUSA
+from .api import gbm_metadata
 
 from .config import (
     USER_EMAIL, USER_PASSWORD, CLIENT_ID, SINGLE_REQUEST_TIMEOUT,
@@ -99,12 +100,12 @@ class GBMPlusAPI(object):
         # API endpoints by section
         self.accounts = Accounts(self._session) 
         self.transfers = Transfers(self._session)
-        self.orders = Orders(self._session,
-                             accounts={element["name"]: element for element in self.accounts.getAccounts()},
-                             trading_types=TradingTypes
-        )
+        self.orders = Orders(self._session, trading_types=TradingTypes)
         self.tradingUSA = TradingUSA(self._session)
-
+        
+        # Initialize Metadata
+        gbm_metadata.init()
+        gbm_metadata.accounts_dict = {element["name"]: element for element in self.accounts.getAccounts()}
 
 class OrderTypes(Enum):
     Buy = 1

--- a/gbmplus/api/gbm_metadata.py
+++ b/gbmplus/api/gbm_metadata.py
@@ -1,0 +1,2 @@
+def init():
+    global accounts_dict

--- a/gbmplus/api/orders.py
+++ b/gbmplus/api/orders.py
@@ -1,11 +1,11 @@
 from datetime import datetime, timezone
 from ..exceptions import *
+from . import gbm_metadata
 
 class Orders(object):
-    def __init__(self, session, accounts_dict, trading_types):
+    def __init__(self, session, trading_types):
         super(Orders, self).__init__()
-        self._session = session
-        self._accounts_dict = accounts_dict
+        self._session = session        
         self._trading_types = trading_types
 
     def generateOrderObject(self, legacy_contract_id, issuer, quantity, order_type, trading_type, instrument_type, price=None):
@@ -94,7 +94,7 @@ class Orders(object):
                 
         resource = "https://homebroker-api.gbm.com/GBMP/api/Operation/RegisterCapitalOrder"
         
-        legacy_contract_id = self._accounts_dict.get(strategy_name).get("legacy_contract_id")
+        legacy_contract_id = gbm_metadata.accounts_dict.get(strategy_name).get("legacy_contract_id")
         order = self.generateOrderObject(legacy_contract_id, issuer, quantity, order_type, trading_type, instrument_type, price)
         
         payload = {
@@ -102,7 +102,9 @@ class Orders(object):
             "duration": duration,
             "algoTradingTypeId": order.get("algoTradingTypeId"),
             "orders": [order]
-        }                
+        }
+        print(payload)
+        exit()         
 
         return self._session.post(metadata, resource, payload)
     

--- a/gbmplus/api/orders.py
+++ b/gbmplus/api/orders.py
@@ -102,9 +102,7 @@ class Orders(object):
             "duration": duration,
             "algoTradingTypeId": order.get("algoTradingTypeId"),
             "orders": [order]
-        }
-        print(payload)
-        exit()         
+        }             
 
         return self._session.post(metadata, resource, payload)
     


### PR DESCRIPTION
@KevinEsh 
Fixes #3

The main intention of this Python library is to implement most of the GBM API calls available. I'm not entirely in favor of encapsulating or hiding implementation details. It is my intention to reflect exactly what data the API is expecting in each method.

However, I do realize this means we need to take extra steps to perform simple operations.

What I propose is to add extra methods that encapsulate some of these details and that make it easier to interact with the API.

For example, I've added submitOrderToStrategy() which generates an order in just one step:

``` python
order_result = gbm.orders.submitOrderToStrategy(
    strategy_name="Swensen",    
    issuer = 'FUNO 11',
    quantity = 1,
    order_type = gbmplus.OrderTypes.Buy,
    trading_type = gbmplus.TradingTypes.Market,
    instrument_type = gbmplus.InstrumentTypes.IPC,
    duration=1  
)
```

This also takes into consideration caching useful metadata (like an account dictionary) when initializing the trader object.

I've created gbm_metadata.py, which may include data worth caching:

``` python
def init():
    global accounts_dict
```

This module is initialized when creating the GBMPlusAPI object and may be accessed/modified at anytime:
``` python
# Initialize Metadata
gbm_metadata.init()
gbm_metadata.accounts_dict = {element["name"]: element for element in self.accounts.getAccounts()}
```

This way, details like legacy_contract_id are encapsulated:

``` python
def submitOrderToStrategy(self, strategy_name, issuer, quantity, order_type, trading_type, instrument_type, price=None, duration=1):
    .
    .    
    legacy_contract_id = gbm_metadata.accounts_dict.get(strategy_name).get("legacy_contract_id")
    order = self.generateOrderObject(legacy_contract_id, issuer, quantity, order_type, trading_type, instrument_type, price)
```